### PR TITLE
Fixed cli args not being passed to winrm connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.py[cod]
 .venv
+*.log


### PR DESCRIPTION
The existing test missed this, but the winrm connector was not receiving any of the args.


## Bench Test
```
pyinfra --debug @winrm/192.168.1.135 --user <username> —password <password>  --port 5986 exec -- dir
```


## Previous Output

```bash
--> Connecting to hosts...
    [pyinfra_windows.connectors.winrm] Connecting to: @winrm/192.168.1.135 ({'winrm_transport': 'plaintext', 'winrm_read_timeout_sec': 30, 'winrm_operation_timeout_sec': 20})
    [pyinfra_windows.connectors.winrm] host_and_port: 192.168.1.135:None
    [pyinfra_windows.connectors.winrm] 'username'
    [@winrm/192.168.1.135] Authentication error ()
    [pyinfra.api.state] Failing hosts: @winrm/192.168.1.135

--> Disconnecting from hosts...
--> pyinfra error: No hosts remaining!

```

## New Output

```bash
…

[--> Connecting to hosts...
    [pyinfra.connectors.ssh] Connecting to: 192.168.1.135 ({'allow_agent': True, 'look_for_keys': True, '_pyinfra_ssh_forward_agent': False, '_pyinfra_ssh_config_file': None, '_pyinfra_ssh_known_hosts_file': None, '_pyinfra_ssh_strict_host_key_checking': 'accept-new', '_pyinfra_ssh_paramiko_connect_kwargs': None, 'username': '****', 'port': 5986, 'timeout': 10, 'password': '****'})
...
@winrm/192.168.1.135] d-r---         6/25/2025   3:19 PM                Searches                                                             
[@winrm/192.168.1.135] d-r---         6/25/2025   3:19 PM                Videos                                                               
[@winrm/192.168.1.135] 
[@winrm/192.168.1.135] 
[@winrm/192.168.1.135] 
[@winrm/192.168.1.135] #< CLIXML
[@winrm/192.168.1.135] <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>
    [@winrm/192.168.1.135] Success

--> Results:
    Operation            Hosts   Success   Error   No Change   
    server.shell (dir)   1       1         -       -           
```
