### PR TITLE
Drop python 3.8. pyinfra supports python >=3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           - os: macos-12
             python-version: "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 version = "0.0.1"
 name = "pyinfra-windows"
 description = ""
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "pyinfra==3.0.2"
 ]


### PR DESCRIPTION
Pyinfra supports python >=3.9. This PR updates pyinfra-windows to match.