### PR TITLE
Change CI macos-12->macos-13. macos-12 runner images was removed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-          - os: macos-12
+          - os: macos-13
             python-version: "3.11"
           - os: windows-2022
             python-version: "3.11"


### PR DESCRIPTION
I noticed the CI for macos-12 just runs until timeout. Github actions has not supported macos-12 for some time now. https://github.com/actions/runner-images/issues/10721
