### PR TITLE
Support some winrm.run_shell_command global arguments.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+
+test:
+	hatch run test:all


### PR DESCRIPTION
`connectors.winrm.run_shell_command` did not properly support the pyinfra [Global arguments](https://docs.pyinfra.com/en/3.x/arguments.html#shell-control-features). This PR adds support for some of them.

## Added
* _env support in `winrm.run_shell_command`.
* _shell_executable support in `winrm.run_shell_command`.
* _success_exit_codes support in `winrm.run_shell_command`.
* TODOs for handling other global arguments in `winrm.run_shell_command`.

## Fixed
* TODOs in `tests/test_winrm_connector.py`
* Improper mocking in `tests/test_winrm_connector.py`. (This hid the issue fixed in #8)