### PR TITLE
Remove ValueError for winget packages with no version

### DIFF
--- a/tests/operations/winget.packages/add_packages.json
+++ b/tests/operations/winget.packages/add_packages.json
@@ -1,8 +1,10 @@
-{"args": ["Notepad++.Notepad++"],
+{"args": [[
+	"Notepad++.Notepad++", "Microsoft.DotNet.SDK.7=7.0.200"
+	]],
     "facts": {
         "winget.WingetPackages": {}
     },
     "commands": [
-        "Notepad++.Notepad++"
+        "'winget install --no-upgrade --silent --exact Notepad++.Notepad++;' 'winget install --no-upgrade --silent --exact Microsoft.DotNet.SDK.7 --version 7.0.200;'"
     ]
 }


### PR DESCRIPTION
Allows commands like `winget.packages("Notepad++.Notepad++")` to work.  This also fixes the `winget.packages/add_packages.json`.

Note that this still doesn't add the latest boolean, but it should be trivial to do so. 
When lastest=True and no package version is specified, the version could become "latest" and the format functions can check if version=="latest" to remove `—no-upgrade`. 