### PR TITLE
Update all facts to use powershell only

### DIFF
--- a/src/pyinfra_windows/facts/server.py
+++ b/src/pyinfra_windows/facts/server.py
@@ -11,8 +11,7 @@ class Home(FactBase):
     Returns the home directory of the current user.
     """
 
-    command = "echo %HOMEPATH%"
-    shell_executable = "cmd"
+    command = "$HOME"
 
     @staticmethod
     def process(output):
@@ -182,8 +181,10 @@ class Date(FactBase):
     Returns the current datetime on the server.
     """
 
-    command = "echo %date%-%time%"
-    shell_executable = "cmd"
+    command = (
+        "[DateTimeOffset]::Now.ToString('yyyy-MM-ddTHH:mm:sszzz', "
+        "[Globalization.CultureInfo]::InvariantCulture)"
+    )
     default = datetime.now
 
     @staticmethod
@@ -217,15 +218,17 @@ class Where(FactBase):
     Returns the full path for a command, if available.
     """
 
-    shell_executable = "cmd"
-
     @staticmethod
     def command(command):
-        return "where {0}".format(command)
+        command = str(command).replace("'", "''")
+        return (
+            "(Get-Command -Name '{0}' -CommandType Application "
+            "-ErrorAction SilentlyContinue | Select-Object -First 1).Source"
+        ).format(command)
 
     @staticmethod
     def process(output):
-        return output[0].rstrip()
+        return output[0].rstrip() if output else None
 
 
 class Hotfixes(FactBase):

--- a/tests/facts/server.Date/server_date.json
+++ b/tests/facts/server.Date/server_date.json
@@ -1,5 +1,5 @@
 {
-    "command": "echo %date%-%time%",
-    "output": ["Sat 01/25/2020-12:09:44.82", ""],
-    "fact": "2020-01-25T12:09:44.820000"
+    "command": "[DateTimeOffset]::Now.ToString('yyyy-MM-ddTHH:mm:sszzz', [Globalization.CultureInfo]::InvariantCulture)",
+    "output": ["2020-01-25T12:09:44-05:00"],
+    "fact": "2020-01-25T12:09:44-05:00"
 }

--- a/tests/facts/server.Home/server_home.json
+++ b/tests/facts/server.Home/server_home.json
@@ -1,5 +1,5 @@
 {
-    "command": "echo %HOMEPATH%",
-    "output": ["\\Users\\vagrant"],
-    "fact": "\\Users\\vagrant"
+    "command": "$HOME",
+    "output": ["C:\\Users\\vagrant"],
+    "fact": "C:\\Users\\vagrant"
 }

--- a/tests/facts/server.Where/server_where.json
+++ b/tests/facts/server.Where/server_where.json
@@ -1,6 +1,6 @@
 {
     "arg": "systeminfo.exe",
-    "command": "where systeminfo.exe",
-    "output": ["C:\\Windows\\System32\\systeminfo.exe", ""],
-    "fact": "C:\\Windows\\System32\\systeminfo.exe"
+    "command": "(Get-Command -Name 'systeminfo.exe' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1).Source",
+    "output": ["C:\\Windows\\system32\\systeminfo.exe"],
+    "fact": "C:\\Windows\\system32\\systeminfo.exe"
 }

--- a/tests/facts/server.Where/server_where_not_found.json
+++ b/tests/facts/server.Where/server_where_not_found.json
@@ -1,6 +1,6 @@
 {
     "arg": "some_non_existing_file",
-    "command": "where some_non_existing_file",
-    "output": [""],
-    "fact": ""
+    "command": "(Get-Command -Name 'some_non_existing_file' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1).Source",
+    "output": [],
+    "fact": null
 }


### PR DESCRIPTION
Most facts use powershell directly or syntax that's mostly compatible except for `Date`, `Home` and `Where`. These were updated to use powershell equivalents.

NOTE: This is a breaking change for `Date` and `Home` facts but since this is unpublished this might be okay

Changes:
- `Home` fact changed to use powershell
- `Home` fact updated to return absolute path with drive
- `Date` fact changed to use powershell
- `Date` fact time format updated to ISO 8601 which matches pyinfra unix facts
- `Where` fact updated to use powershell
- `Where` return None when object does not exist (previously empty string)