### PR TITLE
Fix file.put operation failing on temp file check

### DIFF
--- a/src/pyinfra_windows/operations/files.py
+++ b/src/pyinfra_windows/operations/files.py
@@ -18,6 +18,7 @@ from pyinfra_windows.facts.files import (
     Md5File,
     Sha1File,
     Sha256File,
+    TempDir,
 )
 
 from .util.files import ensure_mode_int
@@ -200,6 +201,7 @@ def put(
 
     mode = ensure_mode_int(mode)
     remote_file = host.get_fact(File, path=dest)
+    temp_dir = host.get_fact(TempDir)
 
     if create_remote_dir:
         yield from _create_remote_dir(state, host, dest, user, group)
@@ -209,7 +211,7 @@ def put(
         yield FileUploadCommand(
             local_file,
             dest,
-            remote_temp_filename=state.get_temp_filename(dest),
+            remote_temp_filename=host.get_temp_filename(dest, temp_directory=temp_dir),
         )
 
         # if user or group:
@@ -228,7 +230,9 @@ def put(
             yield FileUploadCommand(
                 local_file,
                 dest,
-                remote_temp_filename=state.get_temp_filename(dest),
+                remote_temp_filename=host.get_temp_filename(
+                    dest, temp_directory=temp_dir
+                ),
             )
 
             # if user or group:

--- a/tests/operations/files.put/put.json
+++ b/tests/operations/files.put/put.json
@@ -1,0 +1,29 @@
+{
+    "args": [
+        "sshd_config",
+        "C:\\ProgramData\\ssh\\sshd_config"
+    ],
+    "kwargs": {
+        "create_remote_dir": false
+    },
+    "facts": {
+        "files.File": {
+            "path=C:\\ProgramData\\ssh\\sshd_config": null
+        },
+        "files.TempDir": "C:\\Windows\\Temp"
+    },
+    "local_files": {
+        "files": {
+            "sshd_config": "contents"
+        }
+    },
+    "commands": [
+        [
+            "upload",
+            "/sshd_config",
+            "C:\\ProgramData\\ssh\\sshd_config",
+            "C:\\Windows\\Temp/_tempfile_"
+        ]
+    ],
+    "idempotent": false
+}

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -61,7 +61,12 @@ def parse_commands(commands):
                     data = data.decode()
             else:
                 data = str(command.src)
-            json_command = ["upload", data, str(command.dest)]
+            json_command = [
+                "upload",
+                data,
+                str(command.dest),
+                command.remote_temp_filename,
+            ]
 
         elif isinstance(command, FileDownloadCommand):
             json_command = ["download", str(command.src), str(command.dest)]

--- a/tests/util.py
+++ b/tests/util.py
@@ -53,9 +53,6 @@ class FakeState:
         self.inventory = Inventory(([], {}))
         self.config = Config()
 
-    def get_temp_filename(*args):
-        return "_tempfile_"
-
 
 def parse_value(value):
     """
@@ -183,8 +180,14 @@ class FakeHost:
     def noop(self, description):
         self.noop_description = description
 
-    def get_temp_filename(*args):
-        return "_tempfile_"
+    def get_temp_filename(
+        self,
+        hash_key=None,
+        hash_filename=True,
+        *,
+        temp_directory=None,
+    ):
+        return f"{temp_directory}/_tempfile_"
 
     @staticmethod
     def _get_fact_key(fact_cls):


### PR DESCRIPTION
Fixes file.put operation by looking up the temp file name via `Host` rather than `State`. Since pyinfra falls back to using its own `TmpDir` fact, the temp dir needs to be explicitly passed. Finally, adds a test for file.put

Fixes https://github.com/pyinfra-dev/pyinfra-windows/issues/20