### PR TITLE
Fix hash facts conditions/caseing

### DIFF
--- a/src/pyinfra_windows/facts/files.py
+++ b/src/pyinfra_windows/facts/files.py
@@ -55,7 +55,7 @@ class Sha1File(FactBase):
         ).format(path)
 
     def process(self, output):
-        return output[0] if not output else None
+        return output[0].lower() if output else None
 
 
 class Sha256File(FactBase):
@@ -71,7 +71,7 @@ class Sha256File(FactBase):
         ).format(path)
 
     def process(self, output):
-        return output[0] if len(output[0]) > 0 else None
+        return output[0].lower() if output else None
 
 
 class Md5File(FactBase):
@@ -89,4 +89,4 @@ class Md5File(FactBase):
         )
 
     def process(self, output):
-        return output[0] if len(output[0]) > 0 else None
+        return output[0].lower() if output else None

--- a/tests/facts/files.Md5File/hash.json
+++ b/tests/facts/files.Md5File/hash.json
@@ -1,0 +1,6 @@
+{
+    "arg": ["C:\\temp\\somefile.txt"],
+    "command": "if (Test-Path \"C:\\temp\\somefile.txt\") { (Get-FileHash -Algorithm MD5 \"C:\\temp\\somefile.txt\").hash }",
+    "output": ["900150983CD24FB0D6963F7D28E17F72"],
+    "fact": "900150983cd24fb0d6963f7d28e17f72"
+}

--- a/tests/facts/files.Sha1File/hash.json
+++ b/tests/facts/files.Sha1File/hash.json
@@ -1,0 +1,6 @@
+{
+    "arg": ["C:\\temp\\somefile.txt"],
+    "command": "if (Test-Path \"C:\\temp\\somefile.txt\") { (Get-FileHash -Algorithm SHA1 \"C:\\temp\\somefile.txt\").hash }",
+    "output": ["A9993E364706816ABA3E25717850C26C9CD0D89D"],
+    "fact": "a9993e364706816aba3e25717850c26c9cd0d89d"
+}

--- a/tests/facts/files.Sha1File/missing.json
+++ b/tests/facts/files.Sha1File/missing.json
@@ -1,0 +1,6 @@
+{
+    "arg": ["C:\\temp\\missing.txt"],
+    "command": "if (Test-Path \"C:\\temp\\missing.txt\") { (Get-FileHash -Algorithm SHA1 \"C:\\temp\\missing.txt\").hash }",
+    "output": [],
+    "fact": null
+}

--- a/tests/facts/files.Sha256File/hash.json
+++ b/tests/facts/files.Sha256File/hash.json
@@ -1,0 +1,6 @@
+{
+    "arg": ["C:\\temp\\somefile.txt"],
+    "command": "if (Test-Path \"C:\\temp\\somefile.txt\") { (Get-FileHash -Algorithm SHA256 \"C:\\temp\\somefile.txt\").hash }",
+    "output": ["BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD"],
+    "fact": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+}


### PR DESCRIPTION
Updated all hash facts to use lower case for comparison since different paths can produce different casing for the hash (e.g. `get_file_sha1` returns lowercase but `(Get-FileHash).hash` returns upper case). Additionally fixed `Sha1File` conditional being inverted. 